### PR TITLE
Fix undefined method `[]' for nil:NilClass in zone.rb

### DIFF
--- a/lib/pdns_api/zone.rb
+++ b/lib/pdns_api/zone.rb
@@ -346,7 +346,9 @@ module PDNS
       end
 
       # For API v1 there is only one element containing all records
-      current = current.first[:records] unless @http.version == 0
+      unless current.empty? || @http.version.zero?
+        current = current.first[:records]
+      end
 
       # Return the records
       current


### PR DESCRIPTION
Without this fix I get the following:

```
Traceback (most recent call last):
        6: from ./pdns-domain-mover.rb:73:in `<main>'
        5: from ./pdns-domain-mover.rb:73:in `each'
        4: from ./pdns-domain-mover.rb:101:in `block in <main>'
        3: from ~/.gem/ruby/gems/pdns_api-0.1.2/lib/pdns_api/zone.rb:144:in `add'
        2: from ~/.gem/ruby/gems/pdns_api-0.1.2/lib/pdns_api/zone.rb:144:in `map!'
        1: from ~/.gem/ruby/gems/pdns_api-0.1.2/lib/pdns_api/zone.rb:146:in `block in add'
~/.gem/ruby/gems/pdns_api-0.1.2/lib/pdns_api/zone.rb:349:in `current_records': undefined method `[]' for nil:NilClass (NoMethodError)
```
